### PR TITLE
add the initialization of xPassive0 vectors for the IMPORT_GEO=0 situ…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*
 !/.gitignore
+run_test/

--- a/main.cc
+++ b/main.cc
@@ -50,7 +50,12 @@ int main (int argc, char *argv[]) {
 
   // STEP 2: Pre-processing to define the design domain by using passive element assigning method
   PrePostProcess *prepost = new PrePostProcess (opt); // # new
-#if IMPORT_GEO == 1
+#if IMPORT_GEO == 0
+  VecSet(opt->xPassive0, 1.0);  // the whole domain is design domain
+  VecSet(opt->xPassive1, 0.0);  // no non-designable solid domain
+  VecSet(opt->xPassive2, 0.0);  // no fix domain
+  VecSet(opt->xPassive3, 0.0);  // no load domain
+#elif IMPORT_GEO == 1
   prepost->DesignDomainInitialization (opt); // # new
 #endif
 

--- a/options.h
+++ b/options.h
@@ -11,5 +11,5 @@
 #define IMPORT_GEO 1          // 0-Default geometries, 1-Imported CAD geometries
 
 // Physical problems to be studied
-#define PHYSICS 0       //0-Linear elasticity, 1-Compliant, 2-Heat conduction
+#define PHYSICS 0             //0-Linear elasticity, 1-Compliant, 2-Heat conduction
 


### PR DESCRIPTION
1. Add initialization for xPassive vectors, especially for xPassive0 for IMPORT_GEO=0 situations. This will fix the bug that with IMPORT_GEO=0 the code cannot run. The bug is due to that xPassive0 is all zero without initialization, leading to no design domains. Before Nov. 27, xPassive0 is all zero is OK because at that time all the 0 represent design domains, while 1 represents void. So without manual initialization, the xPassive0 vector is created with all zero by default. However, later, multi-domain functionality was added. So the xPassive0 != 0 represents different design domains, while 0 represents void. For example, xPassive0 will not be limited to 0 or 1. It can be 1, 2, 3... depending on the voxel belong to which design domains. In constrast, 0 only represents there is void. Therefore, xPassive0 must be initialized to full of 1 explicitly.
2. Fixed some unsigned int bugs in StlVoxelizer.cc. The program before this modification is OK to run on x86; however, on ARM, there is a bug existing. So the fixing should make the program more robust. 